### PR TITLE
Remove the short_open_tag recommendation

### DIFF
--- a/src/SymfonyRequirements.php
+++ b/src/SymfonyRequirements.php
@@ -358,8 +358,6 @@ class SymfonyRequirements extends RequirementCollection
             );
         }
 
-        $this->addPhpConfigRecommendation('short_open_tag', false);
-
         $this->addPhpConfigRecommendation('magic_quotes_gpc', false, true);
 
         $this->addPhpConfigRecommendation('register_globals', false, true);


### PR DESCRIPTION
On Symfony Slack, @jrobeson initiated a discussion about the need of this recommendation. Apparently, it's not strictly needed for making Symfony run smoothly.