### PR TITLE
Expose a vendor binary "requirements-checker"

### DIFF
--- a/bin/requirements-checker
+++ b/bin/requirements-checker
@@ -1,0 +1,4 @@
+#!/usr/bin/env php
+<?php
+
+include('check.php');

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
     "require": {
         "php": ">=5.3.9"
     },
+    "bin": [
+        "bin/requirements-checker"
+    ],
     "autoload": {
         "psr-4": { "Symfony\\Requirements\\": "src/" }
     },


### PR DESCRIPTION
This lets Composer install a binary "requirements-checker" in the binaries directory (`vendor/bin` by default) of the application that requires this package.

Resolves #9.