### PR TITLE
Added "post_max_size" and "upload_max_filesize"

### DIFF
--- a/src/SymfonyRequirements.php
+++ b/src/SymfonyRequirements.php
@@ -360,6 +360,14 @@ class SymfonyRequirements extends RequirementCollection
 
         $this->addPhpConfigRecommendation('session.auto_start', false);
 
+        $this->addPhpConfigRecommendation('post_max_size', function () {
+            return ini_get('post_max_size') < ini_get('memory_limit');
+        }, true, '"memory_limit" should be superior than "post_max_size".');
+
+        $this->addPhpConfigRecommendation('upload_max_filesize', function () {
+            return ini_get('upload_max_filesize') < ini_get('post_max_size');
+        }, true, '"post_max_size" should be superior than "upload_max_filesize".');
+
         $this->addRecommendation(
             class_exists('PDO'),
             'PDO should be installed',


### PR DESCRIPTION
Here'e a proposal to follow official PHP recommendations (http://php.net/manual/en/ini.core.php#ini.post-max-size).

Doing so will prevent the server to crash before the application can gracefully handle the error (i.e allow the Form component to add the proper error).

I've never contributed to this repo so I don't know if this change is correct but you can get the idea.

What do you think? Thanks!