### PR TITLE
Don't hardcode check.php

### DIFF
--- a/public/check.php
+++ b/public/check.php
@@ -419,7 +419,7 @@ $hasMinorProblems = (bool) count($minorProblems);
 
                         <ul class="symfony-install-continue">
                             <?php if ($hasMajorProblems || $hasMinorProblems): ?>
-                                <li><a href="check.php">Re-check configuration</a></li>
+                                <li><strong>Refresh the page to re-check configuration</strong></li>
                             <?php endif; ?>
                         </ul>
                     </div>


### PR DESCRIPTION
The default NGINX configuration (https://symfony.com/doc/current/setup/web_server_configuration.html#nginx) doesnt allow `check.php` to be accessed.

As a work-around i renamed it to index.php, in this case "Re-check" will response a 404, as the script still assumes check.php for a filename.

This solves it.