### PR TITLE
Allow Docker to identify as localhost

### DIFF
--- a/public/check.php
+++ b/public/check.php
@@ -15,7 +15,7 @@ if (!isset($_SERVER['HTTP_HOST'])) {
     exit("This script cannot be run from the CLI. Run it from a browser.\n");
 }
 
-if (!in_array(@$_SERVER['REMOTE_ADDR'], array(
+if (@$_SERVER['SYMFONY_REQUIREMENT_CHECK'] !== '1' && !in_array(@$_SERVER['REMOTE_ADDR'], array(
     '127.0.0.1',
     '::1',
 ))) {

--- a/public/check.php
+++ b/public/check.php
@@ -15,7 +15,7 @@ if (!isset($_SERVER['HTTP_HOST'])) {
     exit("This script cannot be run from the CLI. Run it from a browser.\n");
 }
 
-if (@$_SERVER['SYMFONY_REQUIREMENT_CHECK'] !== '1' && !in_array(@$_SERVER['REMOTE_ADDR'], array(
+if (@$_SERVER['SYMFONY_REQUIREMENTS_CHECKER'] !== '1' && !in_array(@$_SERVER['REMOTE_ADDR'], array(
     '127.0.0.1',
     '::1',
 ))) {


### PR DESCRIPTION
In docker landscape we need another way to identity as localhost a.k.a "dev"

This allows using e.g. the following docker-compose setup for dev:

```yaml
services:
  app:
    build: ./php
    environment:
      - SYMFONY_REQUIREMENTS_CHECKER=1
```

At this point accessing `/check.php` is allowed, and is a user responsibility.

IIUC it should be possible (conceptually at least) to run a requirement check on a production server in "development mode".

`SYMFONY_REQUIREMENTS_CHECKER=1` assumes we're in development mode.