### PR TITLE
Fix PHPDoc in RequirementCollection

### DIFF
--- a/src/RequirementCollection.php
+++ b/src/RequirementCollection.php
@@ -73,7 +73,7 @@ class RequirementCollection implements \IteratorAggregate
      * Adds a mandatory requirement in form of a PHP configuration option.
      *
      * @param string        $cfgName           The configuration name used for ini_get()
-     * @param bool|callback $evaluation        Either a boolean indicating whether the configuration should evaluate to true or false,
+     * @param bool|callable $evaluation        Either a boolean indicating whether the configuration should evaluate to true or false,
      *                                         or a callback function receiving the configuration value as parameter to determine the fulfillment of the requirement
      * @param bool          $approveCfgAbsence If true the Requirement will be fulfilled even if the configuration option does not exist, i.e. ini_get() returns false.
      *                                         This is helpful for abandoned configs in later PHP versions or configs of an optional extension, like Suhosin.
@@ -91,7 +91,7 @@ class RequirementCollection implements \IteratorAggregate
      * Adds an optional recommendation in form of a PHP configuration option.
      *
      * @param string        $cfgName           The configuration name used for ini_get()
-     * @param bool|callback $evaluation        Either a boolean indicating whether the configuration should evaluate to true or false,
+     * @param bool|callable $evaluation        Either a boolean indicating whether the configuration should evaluate to true or false,
      *                                         or a callback function receiving the configuration value as parameter to determine the fulfillment of the requirement
      * @param bool          $approveCfgAbsence If true the Requirement will be fulfilled even if the configuration option does not exist, i.e. ini_get() returns false.
      *                                         This is helpful for abandoned configs in later PHP versions or configs of an optional extension, like Suhosin.


### PR DESCRIPTION
Prevents warnings from PHPStan like : 

```
Parameter #2 $evaluation of method
Symfony\Requirements\RequirementCollection::addPhpConfigRequirement()
expects bool|Symfony\Requirements\callback, Closure() given.
```